### PR TITLE
Made example page work in IE

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -209,7 +209,7 @@
 				console && console[profiler] && console[profiler](type);
 				window.grid = new DobyGrid(opts).appendTo($('#gridwrapper').empty());
 				if (example[1]) example[1](window.grid);
-				console[profiler + 'End'](type);
+				console && console[profiler + 'End'] && console[profiler + 'End'](type);
 			};
 
 			// Load "css" or "less" theme files


### PR DESCRIPTION
Added a check for console and profiler to make sure the examples work in IE. (IEs console does not have a time method and will stop the execution of the page on a JavaScript error).
