### PR TITLE
Feature columnautowidth

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -9305,6 +9305,11 @@
 				}
 			}
 
+			// If toggling minColumnWidth options, need to refit column minwidths
+			if (options.minColumnWidth && options.minColumnWidth === "headerContent" && self.options.minColumnWidth !== options.minColumnWidth) {
+				fitColumnsToHeader();
+			}
+
 			// If changing row height, need to recalculate positions
 			var recalc_heights = options.rowHeight != self.options.rowHeight;
 


### PR DESCRIPTION
As described in https://github.com/globexdesigns/doby-grid/issues/98 i added an option "fitColumnsToHeader". If activated:

1.) All Columns will be resized so that the complete content of theire headers is visible
2.) The minWidth of all columns will be set to whatever is larger the initial minWidth or the size of the content in the header.

The result is, that columns cannot be resized to be smaller than their headers content.
