### PR TITLE
Prevent window.resize when target is not window

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -6416,7 +6416,7 @@
 		 * @method handleWindowResize
 		 * @memberof DobyGrid
 		 * @private
-		 * 
+		 *
 		 * @param {object} evt - Javascript event object
 		 */
 		handleWindowResize = function (evt) {


### PR DESCRIPTION
Prevent handleWindowResize if the target is not window. Sometimes events named "resize" do bubble up (i.e. from jquery.ui elements). This causes handleWindowResize to be executed which shouldn't be.
