### PR TITLE
Forcing the aggregators to reset each time the are processed (#113)

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -2613,8 +2613,6 @@
 					column_id, aggreg_idx,
 					items = filteredItems;
 
-				// Reset the aggregators each time the aggregators are processsed
-				resetAggregators();
 
 				// Loop through the data and process the aggregators
 				for (i = 0, l = items.length; i < l; i++) {
@@ -9250,6 +9248,9 @@
 							invalidateRows([ci]);
 						}
 					}
+
+					// Reset the aggregators each time the aggregators are processsed
+					resetAggregators();
 
 					// Re-process aggregators and re-render rows
 					self.collection.refresh();


### PR DESCRIPTION
adding `resetAggregators` to the `processAggregators` method; not added to the `processGroupAggregators` as I'm unsure if it is appropriate
