### PR TITLE
More consistent shift click behaviour

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -6046,7 +6046,7 @@
 						deselectCells();
 						self.selectRows(cell.row, cell.row, true);
 					}
-					console.log(self.selection);
+
 					clearTextSelection();
 
 				} else {


### PR DESCRIPTION
As mentioned in #112 i added more consistent behaviour for shift selection when rowBasedSelection is used. Please especially review #L7400.

If a complete row is excluded from selection (all its cells are excluded) it is no longer returned when using Range.toRows(). Does this fix a bug or break a feature when using cell range selection?
