### PR TITLE
Fixed #128

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -2658,7 +2658,12 @@
 				}
 
 				var result = cache.modelsById[id];
-				return result ? [this.items.indexOf(result), result] : null;
+				var idx = this.items.indexOf(result);
+				if (result && result.id === obj.id && idx < 0) {
+					result = null;
+					delete cache.modelsById[id];
+				}
+				return result ? [idx, result] : null;
 			};
 
 


### PR DESCRIPTION
- If the index is < 0 and the result id equals the object id the item has been removed before and the result must therefor be null to enable the grid to add new items with the same id after they have been reset. See #128
