### PR TITLE
Introduced option "showSortIndicator" to give the ability to (if set to ...

### DIFF
--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -454,6 +454,7 @@
 			selectedClass:			"selected",
 			shiftSelect:			true,
 			showHeader:				true,
+			showSortIndicator:		true,
 			stickyFocus:			false,
 			stickyGroupRows:		false,
 			tooltipType:			"popup",
@@ -8344,7 +8345,7 @@
 				html.push('>');
 				html.push('<span class="' + classcolumnname + '">' + column.name + '</span>');
 
-				if (column.sortable) {
+				if (column.sortable && self.options.showSortIndicator) {
 					html.push('<span class="' + classsortindicator + '"></span>');
 				}
 
@@ -10188,7 +10189,7 @@
 		 * @private
 		 */
 		styleSortColumns = function () {
-			if (!self.options.showHeader) return;
+			if (!self.options.showHeader || !self.options.showSortIndicator) return;
 
 			var headerColumnEls = $headers.children();
 			headerColumnEls


### PR DESCRIPTION
...false) hide the sortIndicator that doby-grid will automatically create. This is important if users have implemented their own sort mechanism
