### PR TITLE
Fix issues that occur on first run

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,7 +131,6 @@ module.exports = function (grunt) {
 	grunt.loadNpmTasks('grunt-contrib-uglify');
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-jscs');
-	grunt.loadNpmTasks('grunt-jsdoc');
 	grunt.loadNpmTasks('grunt-lesslint');
 
 	// Grunt "default" task (validation and unit tests only)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"grunt-contrib-uglify": "^0.2.2",
 		"grunt-contrib-watch": "^0.6.1",
 		"grunt-jscs": "^0.6.2",
-		"grunt-jsdoc": "^0.5.7",
 		"grunt-lesslint": "^0.15.0"
 	},
 	"licenses": [{


### PR DESCRIPTION
This fixes two minor problems: grunt-jsdoc isn't defined in the dev dependencies and the README doesn't mention that `bower install` needs to be run.
