### PR TITLE
Add option to fetch extra results in remote fetch

### DIFF
--- a/examples/remote.js
+++ b/examples/remote.js
@@ -193,8 +193,8 @@ define(['backbone', 'dataset'], function (Backbone, dataset) {
 			}, 5);
 		};
 
-		var onLoading = function () {
-			if (!this.grid.$el) return;
+		var onLoading = function (loadingVisibleRows) {
+			if (!this.grid.$el || !loadingVisibleRows) return;
 
 			// Generate a loader overlay
 			if (!this.loader) {
@@ -208,8 +208,8 @@ define(['backbone', 'dataset'], function (Backbone, dataset) {
 			this.loader.css('opacity', 1);
 		};
 
-		var onLoaded = function () {
-			if (!this.grid.$el || !this.loader) return;
+		var onLoaded = function (loadingVisibleRows) {
+			if (!this.grid.$el || !this.loader || !loadingVisibleRows) return;
 			this.loader.css('opacity', 0);
 		};
 
@@ -266,7 +266,8 @@ define(['backbone', 'dataset'], function (Backbone, dataset) {
 			}],
 
 			data: remotedata,
-			quickFilter: true
+			quickFilter: true,
+			rowsToPrefetch: 20
 		};
 	}];
 });

--- a/src/doby-grid.js
+++ b/src/doby-grid.js
@@ -377,6 +377,7 @@ var DobyGrid = function (options) {
 		rowHeight:				28,
 		rowSpacing:				0,
 		rowBasedSelection:		false,
+		rowsToPrefetch:			0,
 		scrollbarPosition:		"right",
 		scrollLoader:			null,
 		selectable:				true,
@@ -6736,6 +6737,14 @@ var DobyGrid = function (options) {
 				from = vp.top,
 				to = vp.bottom;
 
+			// Decrease likelihood that user sees empty rows before the results
+			// load by prefetching extra ones.
+			if (vScrollDir == -1) {
+				from -= self.options.rowsToPrefetch;
+			} else {
+				to += self.options.rowsToPrefetch;
+			}
+
 			// Don't attempt to fetch more results than there are
 			if (from < 0) from = 0;
 			if (self.collection.length > 0) to = Math.min(to, self.collection.length - 1);
@@ -6820,6 +6829,10 @@ var DobyGrid = function (options) {
 
 			var oldvariableRowHeight;
 
+			// Determine if rows to load are already visible by checking for
+			// overlap between we're fetching and current visible ones.
+			var loadingVisibleRows = newFrom <= vp.bottom && vp.top <= newTo;
+
 			// Run the fetcher
 			remoteFetcher({
 				columns: cache.activeColumns,
@@ -6879,7 +6892,7 @@ var DobyGrid = function (options) {
 				dfd.resolve();
 			}, function () {
 				dfd.resolve();
-			});
+			}, loadingVisibleRows);
 
 			return dfd.promise();
 		};
@@ -6933,14 +6946,18 @@ var DobyGrid = function (options) {
 	 * @memberof DobyGrid
 	 * @private
 	 *
-	 * @param	{object}	options			- Fetching options
-	 * @param	{function}	callback		- Callback function
-	 * @param	{function}	clear_callback	- Callback fired if the timeout was cleared
+	 * @param	{object}	options				- Fetching options
+	 * @param	{function}	callback			- Callback function
+	 * @param	{function}	clear_callback		- Callback fired if the timeout was cleared
+	 * @param	{boolean}	loadingVisibleRows	- If true, rows being loaded are inside the visible range
 	 *
 	 */
-	remoteFetcher = function (options, callback, clear_callback) {
+	remoteFetcher = function (options, callback, clear_callback, loadingVisibleRows) {
 		callback = callback || function () {};
 		clear_callback = clear_callback || function () {};
+
+		// Assume by default that the rows to load are inside the visible range.
+		loadingVisibleRows = typeof loadingVisibleRows !== 'undefined' ? loadingVisibleRows : true;
 
 		// Ensure basic options are defined
 		if (!options.offset) options.offset = 0;
@@ -6956,7 +6973,7 @@ var DobyGrid = function (options) {
 		remoteTimer = setTimeout(function () {
 			try {
 				// Fire onLoading callback
-				if (typeof self.fetcher.onLoading === 'function') self.fetcher.onLoading();
+				if (typeof self.fetcher.onLoading === 'function') self.fetcher.onLoading(loadingVisibleRows);
 
 				self.fetcher.request = self.fetcher.fetch(options, function (results) {
 					// Empty the request variable so it doesn't get aborted on scroll
@@ -6965,7 +6982,7 @@ var DobyGrid = function (options) {
 					callback(results);
 
 					// Fire onLoaded callback
-					if (typeof self.fetcher.onLoaded === 'function') self.fetcher.onLoaded();
+					if (typeof self.fetcher.onLoaded === 'function') self.fetcher.onLoaded(loadingVisibleRows);
 				});
 			} catch (err) {
 				throw new Error('Doby Grid remote fetching failed due to: ' + err);


### PR DESCRIPTION
This makes it possible for the user to scroll through remotely fetched results without seeing blank cells that are waiting to load (requested in issue #138). It accomplishes this by fetching extra rows, the amount of which is configurable by the developer.

By default, no extra results are fetched and the behaviour remains the same as before. Set the `rowsToPrefetch` option to a value greater than zero to turn on prefetching. In the _Remote Data_ example I set it to prefetch 20 rows, which I found feels good. Scrolling at a reasonably slow, steady pace doesn't show the loading spinner while a faster one does.

Additionally, I pass an extra argument to the fetcher's `onLoading` callback to indicate if any rows being loaded are currently visible. If they are, you probably want to display a loading indicator. If they aren't (i.e. in the best case scenario when you're "beating" the user and successfully fetching results before they scroll to them), the user need not know that requests are being made in the background on their behalf. I modified the _Remote Data_ example to demonstrate this behaviour.

The appropriate number of rows to prefetch will depend on the speed of the AJAX request. If a remote fetch has a lot of overhead, grabbing extra results while you're making the request might be desirable. On the other hand, each individual fetch might be slower due to returning extra rows. This is especially true on the first load — if you set it to prefetch 300 rows but only 20 are initially visible, that's a lot of extra data to wait for at the start. However, the user can then scroll freely for a while before reaching rows that have yet to be fetched. It's a balancing act.
